### PR TITLE
Feature/arm

### DIFF
--- a/client.py
+++ b/client.py
@@ -11,7 +11,7 @@ import boto3
 
 boto3_session = boto3.Session(profile_name='costnorm', region_name='us-east-1')
 bedrock_runtime = boto3_session.client('bedrock-runtime')
-CLAUDE_MODEL_ID = "anthropic.claude-3-sonnet-20240229-v1:0"
+CLAUDE_MODEL_ID = "us.anthropic.claude-3-7-sonnet-20250219-v1:0"
 
 
 load_dotenv()  # load environment variables from .env


### PR DESCRIPTION
이제 arm을 위한 lambda tool을 2개 추가했습니다

```
Query: test_function 아키텍처 보고, x86이면 arm으로 바꿔줄래?


[Calling tool lambda_search with args {'function_name_query': 'test_function'}]
함수 검색 결과에서 "test_function" Lambda 함수를 찾았습니다. 현재 아키텍처는 "x86_64"입니다. 해당 함수의 세부 정보는 다음과 같습니다:
- 함수 이름: test_function
- 런타임: python3.13
- 현재 아키텍처: x86_64
- 마지막 수정일: 2025-05-13

요청하신 대로 이 함수의 아키텍처를 x86_64에서 arm64로 변경하겠습니다. 변경 작업을 실행하겠습니다.
[Calling tool lambda_arch_change with args {'function_name': 'test_function', 'target_arch': 'arm64'}]
성공적으로 "test_function" Lambda 함수의 아키텍처를 x86_64에서 arm64로 변경했습니다.

### 변경 결과 요약:
- **함수 이름**: test_function
- **이전 아키텍처**: x86_64
- **변경된 아키텍처**: arm64
- **상태 메시지**: "test_function architecture updated to arm64"
- **마지막 수정 시간**: 2025-05-13T03:15:58.000+0000
- **현재 상태**: Active (활성화됨)
- **업데이트 상태**: InProgress (진행 중)

Lambda 함수의 아키텍처 변경 프로세스가 진행 중이며 곧 완료될 예정입니다. ARM64 아키텍처로 변경됨으로써 해당 함수는 더 나은 성능과 비용 효율성을 가질 수 있습니다.

```
즉, repo를 던져줘서 호환성 확인 후, 된다고 나오면 사용자가 해당 lambda 이름을 알려주고 변경하라고 하면 알아서 변경해줌!