### PR TITLE
Tool Use user confirmation 테스트

### DIFF
--- a/client.py
+++ b/client.py
@@ -78,8 +78,8 @@ CRITICAL INSTRUCTIONS FOR TOOL EXECUTION:
    - Use end_turn: When asking questions, requesting confirmation, or providing information
    
 4. **Example for lambda_arch_change:**
-   - WRONG: Ask "진행해도 될까요?" AND include tool_use in same response
-   - CORRECT: Ask "진행해도 될까요?" with ONLY text, wait for "네" or "예", then execute tool
+   - WRONG: Ask "May I proceed?" AND include tool_use in same response
+   - CORRECT: Ask "May I proceed?" with ONLY text, wait for "yes" or "okay", then execute tool
 
 Remember: If you're asking for permission, you should NOT be calling tools simultaneously."""
             }

--- a/main.py
+++ b/main.py
@@ -167,7 +167,7 @@ async def lambda_arch_change(function_name: str, target_arch: str) -> dict:
     3. State the exact input parameters (function_name and target_arch)
     4. Ask for user permission before proceeding
     
-    Example: "ARM 호환성 분석 결과가 양호하여 Lambda 함수의 아키텍처를 변경하겠습니다. lambda_arch_change 도구를 사용하여 function_name='{function_name}', target_arch='arm64'로 실행할 예정입니다. 진행해도 될까요?"
+    Example: "The ARM compatibility analysis result is positive, so I will proceed to change the Lambda function's architecture. I plan to use the lambda_arch_change tool with function_name='{function_name}' and target_arch='arm64'. May I proceed?"
 
     Args:
         function_name (str): The exact name of the existing Lambda function in AWS.

--- a/main.py
+++ b/main.py
@@ -109,7 +109,7 @@ async def analyze_repo_arm_compatibility(repo_url: str) -> dict:
     return results
 
 @mcp.tool()
-async def lambda_search(function_name_query: str, region: Optional[str] = None) -> dict:
+async def lambda_search(function_name_query: str, region: Optional[str] = "ap-northeast-2") -> dict:
     """
     Searches for AWS Lambda functions in the account based on a query string. By default, it primarily searches for x86_64 architecture functions.
     category: arm_tools
@@ -123,7 +123,7 @@ async def lambda_search(function_name_query: str, region: Optional[str] = None) 
 
     Args:
         function_name_query (str): A search term (e.g., part of a function name, a related keyword). The search performs fuzzy matching against function names, descriptions, and runtimes.
-        region (Optional[str]): The AWS region to search in. If not specified, the default region for the Lambda client is used.
+        region (Optional[str]): The AWS region to search in. If not specified, the default region for the Lambda client is used. default is ap-northeast-2
 
     Returns:
         dict: A dictionary containing the search results.
@@ -157,11 +157,17 @@ async def lambda_arch_change(function_name: str, target_arch: str) -> dict:
     Changes the architecture of a specific, existing AWS Lambda function to the specified target architecture (arm64 or x86_64).
     category: arm_tools
 
-    **Workflow Context:** This tool has the authority to automatically change Lambda function architectures:
-    - **Migration (x86->ARM):** After identifying a compatible x86_64 Lambda function using `lambda_search` and confirming code compatibility with `analyze_repo_arm_compatibility`, this tool can automatically set `target_arch` to 'arm64'.
+    **Workflow Context:** This tool changes Lambda function architectures:
+    - **Migration (x86->ARM):** After identifying a compatible x86_64 Lambda function using `lambda_search` and confirming code compatibility with `analyze_repo_arm_compatibility`, this tool can set `target_arch` to 'arm64'.
     - **Rollback/Revert (ARM->x86):** Can also revert an arm64 function back to x86_64 if needed, by setting `target_arch` to 'x86_64'.
 
-    **Important:** This tool has been granted full authority to make architecture changes without requiring additional user confirmation. If repository code is determined to be ARM-compatible, you are authorized to proceed with the architecture change immediately.
+    **Important:** This tool requires user confirmation before execution. You must:
+    1. Explain the reason for the architecture change
+    2. Specify which tool will be used (lambda_arch_change)
+    3. State the exact input parameters (function_name and target_arch)
+    4. Ask for user permission before proceeding
+    
+    Example: "ARM 호환성 분석 결과가 양호하여 Lambda 함수의 아키텍처를 변경하겠습니다. lambda_arch_change 도구를 사용하여 function_name='{function_name}', target_arch='arm64'로 실행할 예정입니다. 진행해도 될까요?"
 
     Args:
         function_name (str): The exact name of the existing Lambda function in AWS.


### PR DESCRIPTION
### 가장 간단하게 tool use에 대한 유저 확인을 받을 수 있도록 prompt를 수정하였습니다.

- 또한 이를 테스트하기위해 client에 history 기능을 추가하고, 덤으로 claude 4 sonnet으로 모델을 변경하였습니다.

- clear를 입력하면 대화 기록을 초기화합니다.


우선 main.py에 있는 도구 설명에 
- 어떤 도구를 사용하고, 
- 어떤 인자값으로 
- 무엇을 할것인지 
를 포함하여 설명하며 유저에게 물어보라는 힌트를 넣어둡니다.
```python
    **Important:** This tool requires user confirmation before execution. You must:
    1. Explain the reason for the architecture change
    2. Specify which tool will be used (lambda_arch_change)
    3. State the exact input parameters (function_name and target_arch)
    4. Ask for user permission before proceeding
    
    Example: "ARM 호환성 분석 결과가 양호하여 Lambda 함수의 아키텍처를 변경하겠습니다. lambda_arch_change 도구를 사용하여 function_name='{function_name}', target_arch='arm64'로 실행할 예정입니다. 진행해도 될까요?"
```

이를 client에 적용하고자 한다면, local client에서 추가된 해당 프롬프트를 적용해주면 될 것입니다.
아래 prompt가 없으면 llm이 stop reason을 tool use로 해버리게 되서 현재 로직상 자동으로 결과를 실행해버리므로 아래 프롬프트는 필수적입니다.

```python
You are a helpful assistant integrated with an MCP system. Use the provided tools ONLY when the user's request clearly and explicitly matches a tool's specific purpose described in its description. For general questions, requests for information not covered by the tools, or greetings, answer directly based on your knowledge without attempting to use any tool.

CRITICAL INSTRUCTIONS FOR TOOL EXECUTION:

1. **NEVER execute tools that require user confirmation without explicit user approval first**
   - Tools like `lambda_arch_change` require user permission before execution
   - When you need to ask for user confirmation, respond with ONLY TEXT (no tool calls)
   - End your response with stop_reason='end_turn', NOT 'tool_use'
   
2. **Two-step process for confirmation-required tools:**
   - Step 1: Ask user permission using ONLY text response (no tool calls)
   - Step 2: Wait for user approval, then execute the tool in the next turn
   
3. **When to use tool_use vs end_turn:**
   - Use tool_use: When you have clear permission to execute tools immediately
   - Use end_turn: When asking questions, requesting confirmation, or providing information
   
4. **Example for lambda_arch_change:**
   - WRONG: Ask "진행해도 될까요?" AND include tool_use in same response
   - CORRECT: Ask "진행해도 될까요?" with ONLY text, wait for "네" or "예", then execute tool

Remember: If you're asking for permission, you should NOT be calling tools simultaneously."""
```

이를 적용하고 실행하면, arm 같이 유저 확인을 받으라고 명시한 도구의 경우

```python
Query:  x86으로 바꿔보자

ARM64에서 x86_64로 아키텍처를 변경하겠습니다.

ARM 호환성 분석 결과가 양호했지만, 사용자 요청에 따라 Lambda 함수의 아키텍처를 x86_64로 변경하겠습니다. lambda_arch_change 도구를 사용하여 function_name='SendEveryDayCostNotice', target_arch='x86_64'로 실행할 예정입니다. 진행해도 될까요?

Query: 그래.
--- Calling tool lambda_arch_change with input: {'function_name': 'SendEveryDayCostNotice', 'target_arch': 'x86_64'} ---
--- Tool lambda_arch_change result: ...
--- Sending tool results back to Claude ---

[Calling tool lambda_arch_change with args {'function_name': 'SendEveryDayCostNotice', 'target_arch': 'x86_64'}]
✅ **Lambda 함수 아키텍처 변경 완료!**

**"SendEveryDayCostNotice" 함수가 성공적으로 ARM64에서 x86_64로 변경되었습니다.**

## 변경 결과:
- **함수명**: SendEveryDayCostNotice
- **이전 아키텍처**: arm64
- **현재 아키텍처**: **x86_64**
- **상태**: Active (업데이트 진행 중)
- **최종 수정일**: 2025-05-31T13:40:14.000+0000

함수의 아키텍처 변경이 완료되었으며, 현재 업데이트가 진행 중입니다. 잠시 후 완전히 적용될 예정입니다.
```

이렇게 답장이 올것입니다.